### PR TITLE
Kernel: switch from exfat-nofuse to exfat-linux

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "fs/exfat"]
-path = fs/exfat
-url = https://github.com/dorimanx/exfat-nofuse.git
+	path = fs/exfat
+	url = https://github.com/arter97/exfat-linux

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "fs/exfat"]
+path = fs/exfat
+url = https://github.com/dorimanx/exfat-nofuse.git

--- a/scripts/gcc-wrapper.py
+++ b/scripts/gcc-wrapper.py
@@ -51,6 +51,7 @@ allowed_warnings = set([
     "nfnetlink_queue_core.c:264",
     "nfnetlink_queue_core.c:265",
     "irq.c:159",
+    "super.c:578",
  ])
 
 # Capture the name of the object file, can find it.


### PR DESCRIPTION
exfat-nofuse's development has been stale for more than a year with no clear maintainership. It's also been lacking critical upstream(which is Samsung) changes.